### PR TITLE
Possibility to invoke bridge for dev dependencies of a root package

### DIFF
--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -15,6 +15,7 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
 use Composer\Util\ProcessExecutor;
 
 /**
@@ -139,7 +140,12 @@ class NpmBridge implements NpmBridgeInterface
      */
     public function isDependantPackage(PackageInterface $package)
     {
-        foreach ($package->getRequires() as $link) {
+        $shouldCheckDevPackages = $package instanceof RootPackageInterface;
+
+        foreach (array_merge(
+                     $package->getRequires(),
+                     $shouldCheckDevPackages ? $package->getDevRequires() : array()
+                 ) as $link) {
             if ('eloquent/composer-npm-bridge' === $link->getTarget()) {
                 return true;
             }

--- a/test/suite/NpmBridgeTest.php
+++ b/test/suite/NpmBridgeTest.php
@@ -130,4 +130,14 @@ class NpmBridgeTest extends PHPUnit_Framework_TestCase
             Phake::verify($this->io)->write('Nothing to install')
         );
     }
+
+    public function testWillInvokeBridgeWhenItDefinedAsDevDependency()
+    {
+        $this->rootPackage->setDevRequires(array($this->linkRoot3));
+        Phake::when($this->vendorFinder)->find($this->composer, $this->bridge)
+            ->thenReturn(array($this->packageA));
+        $this->bridge->install($this->composer);
+
+        Phake::verify($this->client)->install();
+    }
 }


### PR DESCRIPTION
Root package can depend on some npm modules for dev purpose only. This patch enables Bridge when `"eloquent/composer-npm-bridge"` listed in `"require-dev"` property of `composer.json`
