### PR TITLE
Correctly get install path from composer

### DIFF
--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -196,7 +196,7 @@ class NpmBridge implements NpmBridgeInterface
                     )
                 );
 
-                $path = $composer-getInstallationManager()
+                $path = $composer->getInstallationManager()
                     ? $composer->getInstallationManager()->getInstallPath($package)
                     : sprintf('%s/%s', $vendorDir, $package->getName())
                 ;


### PR DESCRIPTION
Some plugins for composer can change install path (mnsami/composer-custom-directory-installer), so we have to use path from composer and not to build it ourself.
