### PR TITLE
Allow package to make npm install optional - also fix #13 and #18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ install:
 .PHONY: test coverage open-coverage lint install
 
 test/bin/php-cs-fixer:
-	curl -sSL http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -o test/bin/php-cs-fixer
+	curl -sSL https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -o test/bin/php-cs-fixer
 	chmod +x test/bin/php-cs-fixer

--- a/README.md
+++ b/README.md
@@ -61,19 +61,22 @@ a dependency.
 
 ## Configuration
 
-The following configuration can be added to the `composer.json` `extra` area to
-customize the behaviour.
+The following configuration can be added to `composer.json` `extra/npm-bridge`
+to customize the behaviour on a per-package basis. Values in the root package
+will not currently impact any dependency packages that also use
+`composer-npm-bridge`.
 
 Key|Description
 -|-
-`composer-npm-timeout`|Specify a custom timeout for the installation. The default is 300 seconds.
-`composer-npm-optional`|Skip instead of throwing an exception if `npm` is not found. Other packages using `composer-npm-bridge` that do not set this will still cause an exception.
-
+`timeout`|Specify a custom timeout for the installation. The default is 300 seconds.
+`optional`|Skip instead of throwing an exception if `npm` is not found when processing the package.
 
     ...
     "extra": {
-        "composer-npm-timeout": 9000,
-        "composer-npm-optional": true,
+        "npm-bridge": {
+            "timeout": 9000,
+            "optional": true
+        },
         ...
     }
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ a dependency.
 [npm]: https://npmjs.org/
 [update]: https://npmjs.org/doc/update.html
 
+## Configuration
+
+The following configuration can be added to the `composer.json` `extra` area to
+customize the behaviour.
+
+Key|Description
+-|-
+`composer-npm-timeout`|Specify a custom timeout for the installation. The default is 300 seconds.
+`composer-npm-optional`|Skip instead of throwing an exception if `npm` is not found. Other packages using `composer-npm-bridge` that do not set this will still cause an exception.
+
+
+    ...
+    "extra": {
+        "composer-npm-timeout": 9000,
+        "composer-npm-optional": true,
+        ...
+    }
+
+To disable `composer-npm-bridge` entirely for a single run, set `COMPOSER_NPM_BRIDGE_DISABLE=1` on the environment.
+
+    COMPOSER_NPM_BRIDGE_DISABLE=1 composer install
+
 ## Caveats
 
 Because NPM dependencies are installed underneath the root directory of the

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ a dependency.
 The following configuration can be added to `composer.json` `extra/npm-bridge`
 to customize the behaviour on a per-package basis. Values in the root package
 will not currently impact any dependency packages that also use
-`composer-npm-bridge`.
+`composer-npm-bridge` - each package must define its own options.
 
 Key|Description
 -|-

--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -13,6 +13,10 @@ use Eloquent\Composer\NpmBridge\Exception\NpmNotFoundException;
  */
 class NpmBridge
 {
+    const EXTRA_KEY = 'npm-bridge';
+    const EXTRA_KEY_OPTIONAL = 'optional';
+    const EXTRA_KEY_TIMEOUT = 'timeout';
+
     /**
      * Construct a new Composer NPM bridge plugin.
      *
@@ -154,8 +158,8 @@ class NpmBridge
     {
         $extra = $package->getExtra();
         // Issue #13 - npm can take a while, so allow a custom timeout
-        if (isset($extra['composer-npm-timeout'])) {
-            $this->client->setTimeout(intval($extra['composer-npm-timeout']));
+        if (isset($extra[self::EXTRA_KEY][self::EXTRA_KEY_TIMEOUT])) {
+            $this->client->setTimeout(intval($extra[self::EXTRA_KEY][self::EXTRA_KEY_TIMEOUT]));
         } else {
             $this->client->setTimeout(null);
         }
@@ -168,13 +172,14 @@ class NpmBridge
         }
 
         $extra = $package->getExtra();
-        if (!empty($extra['composer-npm-optional'])) {
+        if (!empty($extra[self::EXTRA_KEY][self::EXTRA_KEY_OPTIONAL])) {
             $this->io->write(
                 sprintf(
                     '<info>Skipping optional NPM dependencies for %s as npm is unavailable</info>',
                     $package->getPrettyName()
                 )
             );
+
             return true;
         }
 

--- a/src/NpmBridgePlugin.php
+++ b/src/NpmBridgePlugin.php
@@ -59,8 +59,8 @@ class NpmBridgePlugin implements PluginInterface, EventSubscriberInterface
 
         // Increased priority to ensure we run before custom installers which are usually default priority
         return [
-            ScriptEvents::POST_INSTALL_CMD => array('onPostInstallCmd', 1),
-            ScriptEvents::POST_UPDATE_CMD => array('onPostUpdateCmd', 1),
+            ScriptEvents::POST_INSTALL_CMD => ['onPostInstallCmd', 1],
+            ScriptEvents::POST_UPDATE_CMD => ['onPostUpdateCmd', 1],
         ];
     }
 

--- a/src/NpmBridgePlugin.php
+++ b/src/NpmBridgePlugin.php
@@ -52,9 +52,15 @@ class NpmBridgePlugin implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
+        // Issue #18 - disable if ENV set
+        if (!empty(getenv('COMPOSER_NPM_BRIDGE_DISABLE'))) {
+            return [];
+        }
+
+        // Increased priority to ensure we run before custom installers which are usually default priority
         return [
-            ScriptEvents::POST_INSTALL_CMD => 'onPostInstallCmd',
-            ScriptEvents::POST_UPDATE_CMD => 'onPostUpdateCmd',
+            ScriptEvents::POST_INSTALL_CMD => array('onPostInstallCmd', 1),
+            ScriptEvents::POST_UPDATE_CMD => array('onPostUpdateCmd', 1),
         ];
     }
 

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -101,6 +101,7 @@ class NpmClient
         } catch (NpmNotFoundException $err) {
             return false;
         }
+
         return true;
     }
 

--- a/test/suite/NpmBridgePluginTest.php
+++ b/test/suite/NpmBridgePluginTest.php
@@ -56,8 +56,8 @@ class NpmBridgePluginTest extends TestCase
 
         $this->assertSame(
             [
-                ScriptEvents::POST_INSTALL_CMD => array('onPostInstallCmd', 1),
-                ScriptEvents::POST_UPDATE_CMD => array('onPostUpdateCmd', 1),
+                ScriptEvents::POST_INSTALL_CMD => ['onPostInstallCmd', 1],
+                ScriptEvents::POST_UPDATE_CMD => ['onPostUpdateCmd', 1],
             ],
             $this->plugin->getSubscribedEvents()
         );

--- a/test/suite/NpmBridgePluginTest.php
+++ b/test/suite/NpmBridgePluginTest.php
@@ -47,10 +47,17 @@ class NpmBridgePluginTest extends TestCase
 
     public function testGetSubscribedEvents()
     {
+        putenv('COMPOSER_NPM_BRIDGE_DISABLE=1');
+        $this->assertSame(
+            [],
+            $this->plugin->getSubscribedEvents()
+        );
+        putenv('COMPOSER_NPM_BRIDGE_DISABLE=');
+
         $this->assertSame(
             [
-                ScriptEvents::POST_INSTALL_CMD => 'onPostInstallCmd',
-                ScriptEvents::POST_UPDATE_CMD => 'onPostUpdateCmd',
+                ScriptEvents::POST_INSTALL_CMD => array('onPostInstallCmd', 1),
+                ScriptEvents::POST_UPDATE_CMD => array('onPostUpdateCmd', 1),
             ],
             $this->plugin->getSubscribedEvents()
         );

--- a/test/suite/NpmBridgeTest.php
+++ b/test/suite/NpmBridgeTest.php
@@ -6,9 +6,9 @@ use Composer\Composer;
 use Composer\Package\Link;
 use Composer\Package\Package;
 use Composer\Package\RootPackage;
+use Eloquent\Composer\NpmBridge\Exception\NpmNotFoundException;
 use Eloquent\Phony\Phpunit\Phony;
 use PHPUnit\Framework\TestCase;
-use Eloquent\Composer\NpmBridge\Exception\NpmNotFoundException;
 
 class NpmBridgeTest extends TestCase
 {
@@ -27,7 +27,7 @@ class NpmBridgeTest extends TestCase
         $this->packageB = new Package('vendorB/packageB', '1.0.0.0', '1.0.0');
         $this->packageC = new Package('vendorC/packageC', '1.0.0.0', '1.0.0');
 
-        $this->packageC->setExtra(array('composer-npm-optional' => 1, 'composer-npm-timeout' => 900));
+        $this->packageC->setExtra([NpmBridge::EXTRA_KEY => [NpmBridge::EXTRA_KEY_OPTIONAL => true, NpmBridge::EXTRA_KEY_TIMEOUT => 900]]);
 
         $this->linkRoot1 = new Link('vendor/package', 'vendorX/packageX');
         $this->linkRoot2 = new Link('vendor/package', 'vendorY/packageY');

--- a/test/suite/NpmBridgeTest.php
+++ b/test/suite/NpmBridgeTest.php
@@ -8,6 +8,7 @@ use Composer\Package\Package;
 use Composer\Package\RootPackage;
 use Eloquent\Phony\Phpunit\Phony;
 use PHPUnit\Framework\TestCase;
+use Eloquent\Composer\NpmBridge\Exception\NpmNotFoundException;
 
 class NpmBridgeTest extends TestCase
 {
@@ -16,6 +17,7 @@ class NpmBridgeTest extends TestCase
         $this->io = Phony::mock('Composer\IO\IOInterface');
         $this->vendorFinder = Phony::mock('Eloquent\Composer\NpmBridge\NpmVendorFinder');
         $this->client = Phony::mock('Eloquent\Composer\NpmBridge\NpmClient');
+        $this->client->valid->returns(true);
         $this->bridge = new NpmBridge($this->io->get(), $this->vendorFinder->get(), $this->client->get());
 
         $this->composer = new Composer();
@@ -23,6 +25,9 @@ class NpmBridgeTest extends TestCase
         $this->rootPackage = new RootPackage('vendor/package', '1.0.0.0', '1.0.0');
         $this->packageA = new Package('vendorA/packageA', '1.0.0.0', '1.0.0');
         $this->packageB = new Package('vendorB/packageB', '1.0.0.0', '1.0.0');
+        $this->packageC = new Package('vendorC/packageC', '1.0.0.0', '1.0.0');
+
+        $this->packageC->setExtra(array('composer-npm-optional' => 1, 'composer-npm-timeout' => 900));
 
         $this->linkRoot1 = new Link('vendor/package', 'vendorX/packageX');
         $this->linkRoot2 = new Link('vendor/package', 'vendorY/packageY');
@@ -31,6 +36,7 @@ class NpmBridgeTest extends TestCase
         $this->installationManager = Phony::mock('Composer\Installer\InstallationManager');
         $this->installationManager->getInstallPath->with($this->packageA)->returns('/path/to/install/a');
         $this->installationManager->getInstallPath->with($this->packageB)->returns('/path/to/install/b');
+        $this->installationManager->getInstallPath->with($this->packageC)->returns('/path/to/install/c');
 
         $this->composer->setPackage($this->rootPackage);
         $this->composer->setInstallationManager($this->installationManager->get());
@@ -39,34 +45,48 @@ class NpmBridgeTest extends TestCase
     public function testInstall()
     {
         $this->rootPackage->setRequires([$this->linkRoot1, $this->linkRoot2, $this->linkRoot3]);
-        $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([$this->packageA, $this->packageB]);
+        $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([$this->packageA, $this->packageB, $this->packageC]);
         $this->bridge->install($this->composer);
 
         Phony::inOrder(
             $this->io->write->calledWith('<info>Installing NPM dependencies for root project</info>'),
+            $this->client->valid->calledWith(),
             $this->client->install->calledWith(null, true),
             $this->io->write->calledWith('<info>Installing NPM dependencies for Composer dependencies</info>'),
+            $this->client->valid->calledWith(),
             $this->io->write->calledWith('<info>Installing NPM dependencies for vendorA/packageA</info>'),
             $this->client->install->calledWith('/path/to/install/a', false),
+            $this->client->valid->calledWith(),
             $this->io->write->calledWith('<info>Installing NPM dependencies for vendorB/packageB</info>'),
-            $this->client->install->calledWith('/path/to/install/b', false)
+            $this->client->install->calledWith('/path/to/install/b', false),
+            $this->client->valid->calledWith(),
+            $this->io->write->calledWith('<info>Installing NPM dependencies for vendorC/packageC</info>'),
+            $this->client->setTimeout->calledWith(900),
+            $this->client->install->calledWith('/path/to/install/c', false)
         );
     }
 
     public function testInstallProductionMode()
     {
         $this->rootPackage->setRequires([$this->linkRoot1, $this->linkRoot2, $this->linkRoot3]);
-        $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([$this->packageA, $this->packageB]);
+        $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([$this->packageA, $this->packageB, $this->packageC]);
         $this->bridge->install($this->composer, false);
 
         Phony::inOrder(
             $this->io->write->calledWith('<info>Installing NPM dependencies for root project</info>'),
+            $this->client->valid->calledWith(),
             $this->client->install->calledWith(null, false),
             $this->io->write->calledWith('<info>Installing NPM dependencies for Composer dependencies</info>'),
+            $this->client->valid->calledWith(),
             $this->io->write->calledWith('<info>Installing NPM dependencies for vendorA/packageA</info>'),
             $this->client->install->calledWith('/path/to/install/a', false),
+            $this->client->valid->calledWith(),
             $this->io->write->calledWith('<info>Installing NPM dependencies for vendorB/packageB</info>'),
-            $this->client->install->calledWith('/path/to/install/b', false)
+            $this->client->install->calledWith('/path/to/install/b', false),
+            $this->client->valid->calledWith(),
+            $this->io->write->calledWith('<info>Installing NPM dependencies for vendorC/packageC</info>'),
+            $this->client->setTimeout->calledWith(900),
+            $this->client->install->calledWith('/path/to/install/c', false)
         );
     }
 
@@ -76,6 +96,7 @@ class NpmBridgeTest extends TestCase
         $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([]);
         $this->bridge->install($this->composer, true);
 
+        $this->client->valid->calledWith();
         $this->client->install->calledWith(null, true);
     }
 
@@ -102,6 +123,31 @@ class NpmBridgeTest extends TestCase
         );
     }
 
+    public function testInstallOptional()
+    {
+        $this->client->valid->returns(false);
+        $this->client->install->with('/path/to/install/a')->throws(NpmNotFoundException::class);
+        $this->client->install->with('/path/to/install/c')->returns();
+
+        $this->rootPackage->setRequires([$this->linkRoot1, $this->linkRoot2]);
+        $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([$this->packageC, $this->packageA]);
+        try {
+            $this->bridge->install($this->composer);
+        } catch (Exception $err) {
+        }
+
+        Phony::inOrder(
+            $this->io->write->calledWith('<info>Installing NPM dependencies for root project</info>'),
+            $this->io->write->calledWith('Nothing to install'),
+            $this->io->write->calledWith('<info>Installing NPM dependencies for Composer dependencies</info>'),
+            $this->client->valid->calledWith(),
+            $this->io->write->calledWith('<info>Skipping optional NPM dependencies for vendorC/packageC as npm is unavailable</info>'),
+            $this->client->valid->calledWith(),
+            $this->io->write->calledWith('<info>Installing NPM dependencies for vendorA/packageA</info>'),
+            $this->client->install->calledWith('/path/to/install/a', false)
+        );
+    }
+
     public function testUpdate()
     {
         $this->rootPackage->setRequires([$this->linkRoot1, $this->linkRoot2, $this->linkRoot3]);
@@ -110,11 +156,14 @@ class NpmBridgeTest extends TestCase
 
         Phony::inOrder(
             $this->io->write->calledWith('<info>Updating NPM dependencies for root project</info>'),
+            $this->client->valid->calledWith(),
             $this->client->update->calledWith(),
             $this->client->install->calledWith(null, true),
             $this->io->write->calledWith('<info>Installing NPM dependencies for Composer dependencies</info>'),
+            $this->client->valid->calledWith(),
             $this->io->write->calledWith('<info>Installing NPM dependencies for vendorA/packageA</info>'),
             $this->client->install->calledWith('/path/to/install/a', false),
+            $this->client->valid->calledWith(),
             $this->io->write->calledWith('<info>Installing NPM dependencies for vendorB/packageB</info>'),
             $this->client->install->calledWith('/path/to/install/b', false)
         );


### PR DESCRIPTION
Hello

This PR adds ability for a package to give extra composer configuration of `composer-npm-optional` which prevents the `composer-npm-bridge` from throwing an exception if NPM is not found for that particular install. In my use case the module is able to use alternative (albeit less featureful and slower) means to provide the same functionality the NPM modules would provide. So this is a useful thing for me at least.

Additionally, it increases priority of the bridge plugin because I had an issue with installers. Most installers (magento-composer-installer for example) are priority 0. This means there's a battle between what runs first. In the Magento case, on initial install the plugin loaded last meaning the Magento installer failed because node_modules was missing. On normal runs with plugins already installed it seemed to run NPM first. Increasing priority of the NPM bridge to 1 fixed this and it always ran first before the installer, which I believe would be desirable.

I also saw #13 and #18 and implemented those. I did the preferred ENV option for disabling the bridge entirely. And allowed another composer extra key to set a custom timeout if someone has many many packages to install via NPM (`composer-npm-timeout`).

Happy to split the PR if required.