### PR TITLE
Fix for `production` installation argument deprecation

### DIFF
--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -67,7 +67,7 @@ class NpmClient
         if ($isDevMode) {
             $arguments = ['install'];
         } else {
-            $arguments = ['install', '--production'];
+            $arguments = ['install', '--omit=dev'];
         }
 
         if ($timeout === null) {


### PR DESCRIPTION
Fixes "npm WARN config production Use `--omit=dev` instead."

https://docs.npmjs.com/cli/v7/using-npm/config#production